### PR TITLE
Revert "layer.conf: Bump up meta-ros's priority"

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "ros-layer"
 BBFILE_PATTERN_ros-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros-layer = "9"
+BBFILE_PRIORITY_ros-layer = "7"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
This reverts commit cf60859680ec16e17b02ee0970abb44b4e0e120a.

---
This is needed so mavros and ros-mavlink is picked from meta-intel-aero. Since they will be provided by meta-intel-aero, mavros wont happen to use mavlink from meta-uav anymore.